### PR TITLE
Feature: Implement FastAPI server and ChromaDB client for ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 # OS-specific
 .DS_Store
 Thumbs.db
+
+# Local Databases
+chroma_db/

--- a/gcp_rag_api/main.py
+++ b/gcp_rag_api/main.py
@@ -1,0 +1,71 @@
+# gcp_rag_api/main.py (Updated)
+
+# Coded By: Developer B
+# Branch: feature/gcp-api-skeleton
+
+from fastapi import FastAPI, HTTPException
+from typing import List, Dict, Any
+
+# Import our new ChromaDB client
+from .vector_db_client import ChromaDBClient, COLLECTION_NAME
+
+# --- App Initialization & Global Objects ---
+# Create the FastAPI app instance
+app = FastAPI(
+    title="FinRAG GCP API",
+    version="0.1.0",
+    description="API for the RAG-powered Smart Financial Research Assistant."
+)
+
+# Create a single, global instance of our ChromaDB client.
+# This object will be shared across all API requests.
+db_client = ChromaDBClient()
+
+# --- API Events ---
+# Use a startup event to ensure the collection is ready when the API starts.
+@app.on_event("startup")
+def startup_event():
+    """
+    Actions to perform when the API server starts.
+    """
+    print("API is starting up...")
+    db_client.get_or_create_collection(name=COLLECTION_NAME)
+
+# --- API Endpoints ---
+
+@app.get("/", tags=["Health Check"])
+def read_root():
+    """
+    A simple health check endpoint to confirm the API is running.
+    """
+    return {
+        "message": "FinRAG GCP API is running!",
+        "database_status": "connected",
+        "collection_name": db_client.collection.name if db_client.collection else "N/A",
+        "document_count": db_client.count()
+    }
+
+@app.post("/ingest", tags=["Data Ingestion"])
+def ingest_data(data: List[Dict[str, Any]]):
+    """
+    Receives processed data and stores it in the ChromaDB vector store.
+    
+    The expected format for each item in the list is a dictionary with keys:
+    'id', 'text', 'embedding', and 'metadata'.
+    """
+    if not data:
+        raise HTTPException(status_code=400, detail="No data provided for ingestion.")
+
+    try:
+        # Use our client to add the data to the database.
+        db_client.add_nodes(data)
+        
+        return {
+            "status": "success",
+            "message": f"Successfully ingested {len(data)} nodes into collection '{db_client.collection.name}'.",
+            "current_document_count": db_client.count()
+        }
+    except Exception as e:
+        # If anything goes wrong during ingestion, return a detailed error.
+        print(f"Error during ingestion: {e}")
+        raise HTTPException(status_code=500, detail=f"An internal error occurred during data ingestion: {e}")

--- a/gcp_rag_api/vector_db_client.py
+++ b/gcp_rag_api/vector_db_client.py
@@ -1,0 +1,73 @@
+# gcp_rag_api/vector_db_client.py
+
+# Coded By: Developer B
+# Branch: feature/gcp-api-skeleton
+
+import chromadb
+from chromadb.types import Collection
+from typing import List, Dict, Any
+
+# Define a path for our local, file-based ChromaDB instance.
+# This will create a 'chroma_db' folder in the project's root directory.
+DB_PATH = "./chroma_db"
+COLLECTION_NAME = "financial_documents"
+
+class ChromaDBClient:
+    """
+    A client to manage interactions with a local ChromaDB vector database.
+    """
+    def __init__(self, path: str = DB_PATH):
+        # Initialize the ChromaDB client. 'PersistentClient' saves the data to disk.
+        self.client = chromadb.PersistentClient(path=path)
+        self.collection = None
+        print(f"ChromaDB client initialized. Database path: {path}")
+
+    def get_or_create_collection(self, name: str = COLLECTION_NAME) -> Collection:
+        """
+        Retrieves an existing collection or creates a new one if it doesn't exist.
+        This is an idempotent operation, which is safe to call multiple times.
+        """
+        print(f"Attempting to get or create collection: '{name}'")
+        self.collection = self.client.get_or_create_collection(name=name)
+        print(f"Collection '{self.collection.name}' is ready.")
+        return self.collection
+
+    def add_nodes(self, nodes_data: List[Dict[str, Any]]) -> None:
+        """
+        Adds processed nodes (chunks with embeddings) to the ChromaDB collection.
+
+        Args:
+            nodes_data: A list of dictionaries, where each dictionary represents
+                        a node and is expected to have 'id', 'text', 'embedding',
+                        and 'metadata' keys.
+        """
+        if not self.collection:
+            raise ValueError("Collection not initialized. Call get_or_create_collection() first.")
+
+        if not nodes_data:
+            print("No nodes to add.")
+            return
+
+        # ChromaDB expects separate lists for ids, documents, metadatas, and embeddings.
+        # We need to transform the data from Developer A's format into this format.
+        ids = [node['id'] for node in nodes_data]
+        documents = [node['text'] for node in nodes_data]
+        embeddings = [node['embedding'] for node in nodes_data]
+        metadatas = [node['metadata'] for node in nodes_data]
+
+        print(f"Adding {len(ids)} documents to collection '{self.collection.name}'...")
+        
+        # The core operation to add data to the vector store.
+        self.collection.add(
+            ids=ids,
+            documents=documents,
+            embeddings=embeddings,
+            metadatas=metadatas
+        )
+        print("Successfully added documents to ChromaDB.")
+
+    def count(self) -> int:
+        """Returns the number of items in the collection."""
+        if not self.collection:
+            return 0
+        return self.collection.count()


### PR DESCRIPTION
Hi @hritxxxk,

This PR contains the initial implementation of the GCP-side API.

**What's included:**
- A basic FastAPI server in `gcp_rag_api/main.py`.
- A client for our local ChromaDB instance in `gcp_rag_api/vector_db_client.py`.
- The `/ingest` endpoint is now functional and saves incoming data to the vector store.
- I've also updated `.gitignore` to exclude the local database directory.

**Action Required for You:**
The `/ingest` endpoint now expects a JSON list, where each object has the following keys:
- `id` (string)
- `text` (string)
- `embedding` (list of floats)
- `metadata` (dictionary)

Your next task is to build the `api_client.py` on your side to format the data this way and send it to my running server at `http://127.0.0.1:8000/ingest`.