### PR TITLE
feat: Implement api_client to send processed nodes to ingest API

### DIFF
--- a/aws_ingestion/api_client.py
+++ b/aws_ingestion/api_client.py
@@ -1,0 +1,55 @@
+# aws_ingestion/api_client.py
+
+# Coded By: Developer A (You)
+# Branch: feature/api-client
+
+import requests
+from typing import List
+from llama_index.core.schema import BaseNode
+
+def send_nodes_to_api(nodes: List[BaseNode], api_url: str):
+    """
+    Formats node data and sends it to the GCP RAG API's /ingest endpoint.
+
+    Args:
+        nodes (List[BaseNode]): The list of nodes with text, metadata, and embeddings.
+        api_url (str): The URL of the ingestion API endpoint.
+
+    Returns:
+        bool: True if the request was successful, False otherwise.
+    """
+    print(f"\n--- Preparing to Send {len(nodes)} Nodes to API ---")
+
+    # 1. Format the data according to the API contract
+    payload = []
+    for node in nodes:
+        if node.embedding is None:
+            print(f"Warning: Skipping node {node.node_id} because it has no embedding.")
+            continue
+            
+        payload.append({
+            "id": node.node_id,
+            "text": node.get_content(),
+            "embedding": node.embedding,
+            "metadata": node.metadata
+        })
+    
+    if not payload:
+        print("Error: No nodes with embeddings to send.")
+        return False
+
+    print(f"Formatted {len(payload)} nodes. Sending data to {api_url}...")
+
+    # 2. Send the data via an HTTP POST request
+    try:
+        response = requests.post(api_url, json=payload, timeout=60) # timeout in seconds
+        
+        # Raise an exception for bad status codes (4xx or 5xx)
+        response.raise_for_status() 
+
+        print(f"Successfully sent data. API Response: {response.json()}")
+        return True
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Failed to send data to API. {e}")
+        return False

--- a/test_local_ingestion.py
+++ b/test_local_ingestion.py
@@ -1,72 +1,50 @@
-# test_local_ingestion.py (Final Version for this feature)
-
-# Coded By: Developer A (You)
-# Branch: feature/local-ingestion-modules
+# test_local_ingestion.py (Updated to include API call)
 
 import sys
 from pathlib import Path
 
-# This is a common pattern to make sure the script can find your modules
 project_root = Path(__file__).parent
 sys.path.append(str(project_root))
 
 from aws_ingestion.document_loader import load_financial_document
 from aws_ingestion.text_processor import process_documents_into_nodes
-from aws_ingestion.embedding_generator import generate_embeddings_for_nodes # <-- IMPORT THE NEW FUNCTION
+from aws_ingestion.embedding_generator import generate_embeddings_for_nodes
+from aws_ingestion.api_client import send_nodes_to_api # <-- IMPORT THE NEW FUNCTION
 
 def main():
     """
-    Tests the full local ingestion pipeline: Load -> Process -> Embed.
+    Tests the full local ingestion pipeline and sends data to the local RAG API.
     """
-    print("--- Starting Full Local Ingestion Pipeline Test ---")
+    print("--- Starting Full Local Ingestion & API Send Test ---")
 
+    # The URL of your collaborator's locally running API
+    GCP_API_URL = "http://127.0.0.1:8000/ingest"
     sample_pdf_path = Path("data/raw/sample-report.pdf")
 
     try:
-        # --- Step 1: Document Loading ---
+        # Step 1: Load
         documents = load_financial_document(sample_pdf_path)
-        if not documents:
-            print("Stopping: No documents were loaded.")
-            return
-
-        # --- Step 2: Text Processing (Chunking) ---
+        # Step 2: Chunk
         nodes = process_documents_into_nodes(documents)
-        if not nodes:
-            print("Stopping: No nodes were created from documents.")
-            return
-
-        # --- Step 3: Embedding Generation ---
+        # Step 3: Embed
         nodes_with_embeddings = generate_embeddings_for_nodes(nodes)
+
         if not nodes_with_embeddings:
-            print("Stopping: Embedding generation failed.")
+            print("Stopping: Pipeline did not produce nodes with embeddings.")
             return
 
-        print("\n--- Final Verification ---")
-        print(f"Total nodes processed: {len(nodes_with_embeddings)}")
+        # --- Step 4: Send Data to Local API ---
+        success = send_nodes_to_api(nodes_with_embeddings, GCP_API_URL)
 
-        if nodes_with_embeddings:
-            first_node = nodes_with_embeddings[0]
-            print(f"Verification for the first node:")
-            print(f"  - Has text: {len(first_node.text) > 0}")
-            print(f"  - Has metadata: {'file_name' in first_node.metadata}")
-            
-            # The most important check for this step
-            print(f"  - Has embedding: {first_node.embedding is not None}")
-            if first_node.embedding:
-                # The all-MiniLM-L6-v2 model produces embeddings of size 384
-                print(f"  - Embedding dimension: {len(first_node.embedding)}")
-                if len(first_node.embedding) == 384:
-                    print("  - Verification successful: Embedding dimension is correct (384).")
-                else:
-                    print(f"  - Verification FAILED: Embedding dimension is {len(first_node.embedding)}, expected 384.")
+        if success:
+            print("\nVerification successful: Data was sent to the API.")
+        else:
+            print("\nVerification FAILED: Data could not be sent. Is the GCP API server running?")
 
-    except FileNotFoundError as e:
-        print(f"Error: {e}")
-        print("Please ensure the file 'sample-report.pdf' exists in the 'data/raw/' directory.")
     except Exception as e:
-        print(f"An unexpected error occurred: {e}")
+        print(f"An unexpected error occurred in the pipeline: {e}")
 
-    print("\n--- Full Local Ingestion Pipeline Test Finished ---")
+    print("\n--- Full Local Ingestion & API Send Test Finished ---")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR completes the "AWS" side of the ingestion pipeline. It introduces the `api_client.py` module.

**Functionality:**
- Takes the processed nodes (with embeddings).
- Formats them into the JSON payload we agreed on.
- Sends them to the `/ingest` endpoint.

I have successfully tested this against your running server and received a `200 OK` response.

After merging, our full data ingestion loop is complete. The next logical step would be to implement the query/retrieval logic on the GCP side.