### PR TITLE
feat(api): implement query endpoint for RAG retrieval

### DIFF
--- a/gcp_rag_api/rag_core.py
+++ b/gcp_rag_api/rag_core.py
@@ -1,0 +1,45 @@
+# gcp_rag_api/rag_core.py
+
+# Coded By: Developer B
+# Branch: feature/query-endpoint
+
+from typing import List, Dict, Any
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from .vector_db_client import ChromaDBClient
+
+# --- Global Initialization ---
+# Initialize the embedding model once to avoid reloading it on every API call.
+# This ensures efficiency.
+print("Initializing embedding model...")
+embed_model = HuggingFaceEmbedding(
+    model_name="sentence-transformers/all-MiniLM-L6-v2"
+)
+print("Embedding model initialized successfully.")
+
+
+def retrieve_relevant_chunks(query: str, db_client: ChromaDBClient, n_results: int = 5) -> List[Dict[str, Any]]:
+    """
+    The core "Retrieval" function of RAG.
+    1. Takes a user's text query.
+    2. Generates an embedding for the query.
+    3. Queries the vector database to find the most relevant text chunks.
+    
+    Args:
+        query (str): The user's question.
+        db_client (ChromaDBClient): An instance of our database client.
+        n_results (int): The number of chunks to retrieve.
+
+    Returns:
+        List[Dict[str, Any]]: The retrieved context from the database.
+    """
+    # 1. Generate embedding for the user's query
+    print(f"Generating embedding for query: '{query}'")
+    query_embedding = embed_model.get_text_embedding(query)
+    
+    # 2. Query the vector database
+    retrieved_results = db_client.query_collection(
+        query_embedding=query_embedding,
+        n_results=n_results
+    )
+    
+    return retrieved_results

--- a/gcp_rag_api/vector_db_client.py
+++ b/gcp_rag_api/vector_db_client.py
@@ -71,3 +71,28 @@ class ChromaDBClient:
         if not self.collection:
             return 0
         return self.collection.count()
+    
+
+
+    def query_collection(self, query_embedding: List[float], n_results: int = 5) -> List[Dict[str, Any]]:
+        """
+        Queries the collection to find the most similar documents to a given embedding.
+
+        Args:
+            query_embedding (List[float]): The embedding vector of the user's query.
+            n_results (int): The number of top similar documents to return.
+
+        Returns:
+            List[Dict[str, Any]]: A list of the most relevant document chunks.
+        """
+        if not self.collection:
+            raise ValueError("Collection not initialized.")
+
+        print(f"Querying collection '{self.collection.name}' for {n_results} results...")
+        
+        results = self.collection.query(
+            query_embeddings=[query_embedding], # Note: ChromaDB expects a list of embeddings
+            n_results=n_results
+        )
+        
+        return results


### PR DESCRIPTION
This commit introduces the core retrieval functionality of the FinRAG system.

It adds the /query endpoint to the FastAPI application, which allows users to submit natural language queries and receive relevant text chunks from the vector database.

Key changes include:
- A new `query_collection` method in the `ChromaDBClient` to perform similarity searches.
- A new `rag_core.py` module containing the `retrieve_relevant_chunks` function, which orchestrates the query embedding and database lookup.
- Integration of the retrieval logic into `main.py` with the `/query` endpoint.

This completes the "Retrieval" part of the RAG pipeline and enables the system to find contextually relevant information.